### PR TITLE
Investigate sporadic failures in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
+    "install:clean": "rm -rf node_modules && yarn",
     "compile": "tsc",
     "test": "jest",
     "lint": "eslint src/**/*.ts src/*.ts",

--- a/src/MockGenerator.ts
+++ b/src/MockGenerator.ts
@@ -105,7 +105,8 @@ class MockBuilder {
         const maximumLength = maxItems ? maxItems : 100
         const minimumLength = minItems ? minItems : 0
         const chosenLength =
-            Math.floor(Math.random() * maximumLength) + minimumLength
+            Math.floor(Math.random() * (maximumLength - minimumLength + 1)) +
+            minimumLength
 
         if (items.constructor.name === 'Array') {
             return items.map((item: any) => this.buildMock(item))

--- a/src/__tests__/MockGenerator.test.ts
+++ b/src/__tests__/MockGenerator.test.ts
@@ -49,7 +49,8 @@ describe('MockGenerator', () => {
             it.each([simpleBlocks.INTEGER, simpleBlocks.NUMBER])(
                 'multipleOf ensures that the generated %s is a multiple of the specified value',
                 type => {
-                    const randomizedMultiple = Math.floor(Math.random() * 100)
+                    const randomizedMultiple =
+                        Math.floor(Math.random() * 100) + 1
                     const schema: any = {
                         type,
                         multipleOf: randomizedMultiple,


### PR DESCRIPTION
In some cases, CI tests around arrays with `minLength` and `maxLength` will fail because the randomly chosen array length was not properly bounded between the extrema.

This also fixes an issue around `multipleOf` sometimes being 0 in tests and failing the tests; `multipleOf` is strictly positive.